### PR TITLE
Remove email contact link from index route

### DIFF
--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -4,7 +4,6 @@ const contacts = [
     title: "linkedin",
     href: "https://www.linkedin.com/in/clement-meyer-2715b554/",
   },
-  { title: "email", href: "mailto:meyclem@gmail.com" },
 ];
 
 // https://remix.run/guides/routing#index-routes


### PR DESCRIPTION
## Summary
Removed the email contact link from the contacts list in the index route.

## Changes
- Removed the email contact entry (`mailto:meyclem@gmail.com`) from the contacts array in `app/routes/_index.tsx`
- The LinkedIn contact link remains unchanged

## Details
This change simplifies the contacts list by removing the email contact option, leaving only the LinkedIn profile link as a way to get in touch.

https://claude.ai/code/session_01F1eBHSqR4Be6gdxqsankHV